### PR TITLE
Security/fix code sec vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Tutte le modifiche importanti a questo progetto saranno documentate in questo fi
 Il formato è basato su [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 e questo progetto aderisce a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2022-01-16
+### Fixed
+- CWE-23: Relative Path Traversal
+- CWE-643: Improper Neutralization of Data within XPath Expressions ('XPath Injection')
+- CWE-611: Improper Restriction of XML External Entity Reference ('XXE')
+- SC2086: Double quote to prevent globbing and word splitting
+- SC2129: Consider using { cmd1; cmd2; } >> file instead of individual redirects
+
+
 ## [2.2.0] - 2022-01-16
 ### Changed
 - Aggiornamento versione di Ubunto da 20.04 a 22.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,10 @@ RUN apt update \
     && apt install -y apache2 \
     && apt install -y ca-certificates \
     && apt install -y php libapache2-mod-php \
-    && apt install -y python2 \
+    && apt install -y python3 \
     && apt install -y cron \
+    && apt install -y pip \
+    && pip install lxml \
     && rm -rf /var/lib/apt/lists/*
 
 COPY scripts/parse-gov-certs.py /usr/local/bin/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@ MIT License
 
 Apache 2.4 per SmartCard TS-CNS (Tessera Sanitaria - Carta Nazionale Servizi)
 
-Copyright (c) 2022 Antonio Musarra's Blog - https://www.dontesta.it
+Copyright (c) 2024 Antonio Musarra's Blog - https://www.dontesta.it
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.markdown
+++ b/README.markdown
@@ -165,8 +165,10 @@ RUN apt update \
     && apt install -y apache2 \
     && apt install -y ca-certificates \
     && apt install -y php libapache2-mod-php \
-    && apt install -y python \
+    && apt install -y python3 \
     && apt install -y cron \
+    && apt install -y pip \
+    && pip install lxml \
     && rm -rf /var/lib/apt/lists/*
 ```
 
@@ -659,7 +661,7 @@ pubblicato recentemente su [Antonio Musarra's Blog](https://www.dontesta.it).
 ## Project License
 The MIT License (MIT)
 
-Copyright &copy; 2022 Antonio Musarra's Blog - [https://www.dontesta.it](https://www.dontesta.it "Antonio Musarra's Blog"), 
+Copyright &copy; 2024 Antonio Musarra's Blog - [https://www.dontesta.it](https://www.dontesta.it "Antonio Musarra's Blog"), 
 [antonio.musarra@gmail.com](mailto:antonio.musarra@gmail.com "Antonio Musarra Email")
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/scripts/auto-update-gov-certificates
+++ b/scripts/auto-update-gov-certificates
@@ -10,8 +10,8 @@ rm -rf "${GOV_TRUST_CERTS_OUTPUT_PATH}"
 
 echo "$(date "+%FT%T") Downloading Gov Certificates..." >> "${LOG_FILE}"
 /usr/local/bin/parse-gov-certs.py \
-    --output-folder ${GOV_TRUST_CERTS_OUTPUT_PATH} \
-    --service-type-identifier ${GOV_TRUST_CERTS_SERVICE_TYPE_IDENTIFIER}
+    --output-folder "${GOV_TRUST_CERTS_OUTPUT_PATH}" \
+    --service-type-identifier "${GOV_TRUST_CERTS_SERVICE_TYPE_IDENTIFIER}"
 
 echo "$(date "+%FT%T") Downloading Gov Certificates...[END]" >> "${LOG_FILE}"
 

--- a/scripts/auto-update-gov-certificates
+++ b/scripts/auto-update-gov-certificates
@@ -13,10 +13,13 @@ echo "$(date "+%FT%T") Downloading Gov Certificates..." >> "${LOG_FILE}"
     --output-folder "${GOV_TRUST_CERTS_OUTPUT_PATH}" \
     --service-type-identifier "${GOV_TRUST_CERTS_SERVICE_TYPE_IDENTIFIER}"
 
-echo "$(date "+%FT%T") Downloading Gov Certificates...[END]" >> "${LOG_FILE}"
+{
+    echo "$(date "+%FT%T") Downloading Gov Certificates...[END]"
 
-echo "$(date "+%FT%T") Save Gov Certificates into ${GOV_TRUST_CERTS_OUTPUT_PATH}" >> "${LOG_FILE}"
-echo "$(date "+%FT%T") Copy Gov Certificates into /etc/ssl/certs/" >> "${LOG_FILE}"
+    echo "$(date "+%FT%T") Save Gov Certificates into ${GOV_TRUST_CERTS_OUTPUT_PATH}"
+    echo "$(date "+%FT%T") Copy Gov Certificates into /etc/ssl/certs/"
+} >> "${LOG_FILE}"
+
 cp "${GOV_TRUST_CERTS_OUTPUT_PATH}"/*.pem /etc/ssl/certs/
 
 echo "$(date "+%FT%T") Re-Hashing /etc/ssl/certs/..." >> "${LOG_FILE}"

--- a/scripts/parse-gov-certs.py
+++ b/scripts/parse-gov-certs.py
@@ -80,6 +80,7 @@ def safe_open(file_path, base_path, mode='r'):
         raise ValueError("File path is outside allowed area")
 
     # If everything is okay, open the file
+    # file deepcode ignore PT: only point to use this function
     return open(full_path, mode)
 
 parser = argparse.ArgumentParser()


### PR DESCRIPTION
PR per nuova release 2.2.1 che contiene le seguenti fix.

### Fixed
- CWE-23: Relative Path Traversal
- CWE-643: Improper Neutralization of Data within XPath Expressions ('XPath Injection')
- CWE-611: Improper Restriction of XML External Entity Reference ('XXE')
- SC2086: Double quote to prevent globbing and word splitting
- SC2129: Consider using { cmd1; cmd2; } >> file instead of individual redirects