### PR TITLE
Aggiornamento action checkout v4 - workflow di pubblicazione docker

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build Docker Image
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin && make release


### PR DESCRIPTION
Github sta incoraggiando ad upgradare tutti i workflow ad azioni che usano node 20 entro aprile 2024. 

Per quanto riguarda la github checkout action è necessario aggiornare la versione almeno alla 4. 

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Questo l'alert completo presente in una delle ultime build : 
"Build and Publish Docker image (via Makefile)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/."

https://github.com/italia/cie-cns-apache-docker/actions/runs/7848070728
