### PR TITLE
Verifica scadenza certificati

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ Tutte le modifiche importanti a questo progetto saranno documentate in questo fi
 Il formato è basato su [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 e questo progetto aderisce a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2025-04-25
+### Added
+- Sullo script `parse-gov-certs.py` è stata aggiunta la funzionalità di controllo della validità del certificato (scadenza)
+- Aggiunto il file requirements.txt per la gestione delle dipendenze Python qualora si volesse eseguire lo script `parse-gov-certs.py` al di fuori del container Docker
+
+### Changed
+- Aggiornamento della documentazione (README)
+- Aggiornamento della documentazione doc-style dello script `parse-gov-certs.py`
+- Refactoring dello script `parse-gov-certs.py` per rimuovere vecchio codice di compatibilità con Python 2
+- Aggiornamento del Dockerfile per l'installazione delle dipendenze Python aggiuntive
+
+### Fixed
+- Revisione della funzione di sanificazione del nome del certificato
+
 ## [2.2.2] - 2025-04-24
 ### Fixed
 - Sovrascrittura dei certificati con lo stesso CN (Common Name) [#28](https://github.com/italia/cie-cns-apache-docker/issues/28)

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN apt update \
     && apt install -y cron \
     && apt install -y pip \
     && pip install lxml \
+    && pip install cryptography \
     && rm -rf /var/lib/apt/lists/*
 
 COPY scripts/parse-gov-certs.py /usr/local/bin/

--- a/README.markdown
+++ b/README.markdown
@@ -169,6 +169,7 @@ RUN apt update \
     && apt install -y cron \
     && apt install -y pip \
     && pip install lxml \
+    && pip install cryptography \
     && rm -rf /var/lib/apt/lists/*
 ```
 
@@ -189,6 +190,12 @@ RUN /usr/local/bin/parse-gov-certs.py \
         --service-type-identifier ${GOV_TRUST_CERTS_SERVICE_TYPE_IDENTIFIER} \
     && cp ${GOV_TRUST_CERTS_OUTPUT_PATH}/*.pem /etc/ssl/certs/
 ```
+
+> Attenzione: dalla release 2.3.0 del progetto, è stata introdotta sullo script `parse-gov-certs.py` la funzionalità di
+> controllo scadenza validità dei certificati. Per impostazione predefinita, lo script non salva i certificati
+> scaduti e scrive un messaggio del tipo `Skipping expired certificate`. Qualora si vogliano salvare i certificati
+> scaduti, è possibile utilizzare l'opzione `--save-expired-certs` e in questo caso lo script salverà i certificati
+> scaduti con il suffisso `_expired` e scriverà un messaggio del tipo `Added certificate: expired...`.
  
 La sezione a seguire del Dockerfile, anch'essa esplicativa, copia le 
 configurazioni di Apache opportunamente modificate al fine di abilitare 

--- a/scripts/parse-gov-certs.py
+++ b/scripts/parse-gov-certs.py
@@ -46,14 +46,8 @@ EXTENSION = ".pem"
 
 
 def get_certs_xml():
-    if sys.version_info[0] == 2:
-        import urllib2
-        request = urllib2
-    else:
-        import urllib.request
-        request = urllib.request
-
-    return request.urlopen(DEFAULT_XML_URI)
+    import urllib.request
+    return urllib.request.urlopen(DEFAULT_XML_URI)
 
 
 def write_certificate(f, x509_cert):

--- a/scripts/parse-gov-certs.py
+++ b/scripts/parse-gov-certs.py
@@ -50,11 +50,10 @@ def get_certs_xml():
     return urllib.request.urlopen(DEFAULT_XML_URI)
 
 
-def write_certificate(f, x509_cert):
-    f.write('-----BEGIN CERTIFICATE-----\n')
-    for line in textwrap.wrap(x509_cert, 65):
-        f.write(line + '\n')
-    f.write('-----END CERTIFICATE-----\n')
+def write_certificate(file, cert):
+    file.write('-----BEGIN CERTIFICATE-----\n')
+    file.writelines(line + '\n' for line in textwrap.wrap(cert, 65))
+    file.write('-----END CERTIFICATE-----\n')
 
 
 def get_service_info(service, namespace):

--- a/scripts/parse-gov-certs.py
+++ b/scripts/parse-gov-certs.py
@@ -105,19 +105,12 @@ parser.add_argument("--service-type-identifier", help="Save certs by Service Typ
 args = parser.parse_args()
 
 if args.output_folder:
-    if os.path.exists(args.output_folder):
-        if not os.path.isdir(args.output_folder):
-            print("Impossible to save certificates in `%s': file exists and is not a folder." % args.output_folder)
-            sys.exit(1)
-    else:
-        os.makedirs(args.output_folder)
+    os.makedirs(args.output_folder, exist_ok=True)
 elif args.output_file:
-    if os.path.exists(args.output_file):
-        if not os.path.isfile(args.output_file):
-            print("Impossible to write on `%s', it's not a file." % args.output_file)
-            sys.exit(1)
-
-        print("File `%s' will be overwritten..." % args.output_file)
+    if os.path.exists(args.output_file) and not os.path.isfile(args.output_file):
+        print(f"Impossible to write on `{args.output_file}`, it's not a file.")
+        sys.exit(1)
+    print(f"File `{args.output_file}` will be overwritten...")
 
 if args.cert_file:
     tree = etree.parse(args.cert_file)

--- a/scripts/parse-gov-certs.py
+++ b/scripts/parse-gov-certs.py
@@ -44,26 +44,30 @@ import os
 DEFAULT_XML_URI = "https://eidas.agid.gov.it/TL/TSL-IT.xml"
 EXTENSION = ".pem"
 
-def get_certs_xml():
-  if sys.version_info[0] == 2:
-    import urllib2
-    request = urllib2
-  else:
-    import urllib.request
-    request = urllib.request
 
-  return request.urlopen(DEFAULT_XML_URI)
+def get_certs_xml():
+    if sys.version_info[0] == 2:
+        import urllib2
+        request = urllib2
+    else:
+        import urllib.request
+        request = urllib.request
+
+    return request.urlopen(DEFAULT_XML_URI)
+
 
 def write_certificate(f, x509_cert):
-  f.write('-----BEGIN CERTIFICATE-----\n')
-  for line in textwrap.wrap(x509_cert, 65):
-    f.write(line+'\n')
-  f.write('-----END CERTIFICATE-----\n')
+    f.write('-----BEGIN CERTIFICATE-----\n')
+    for line in textwrap.wrap(x509_cert, 65):
+        f.write(line + '\n')
+    f.write('-----END CERTIFICATE-----\n')
+
 
 def get_service_info(service, namespace):
-  name = service.find("*/"+namespace+"Name").text
-  x509_cert = service.find("*//"+namespace+"X509Certificate").text
-  return {'name': name, 'x509_cert': x509_cert}
+    name = service.find("*/" + namespace + "Name").text
+    x509_cert = service.find("*//" + namespace + "X509Certificate").text
+    return {'name': name, 'x509_cert': x509_cert}
+
 
 def safe_open(file_path, base_path, mode='r'):
     # Get absolute path of the base directory
@@ -83,6 +87,7 @@ def safe_open(file_path, base_path, mode='r'):
     # file deepcode ignore PT: only point to use this function
     return open(full_path, mode)
 
+
 parser = argparse.ArgumentParser()
 action = parser.add_mutually_exclusive_group(required=True)
 action.add_argument("--output-folder", help="Where to save the certs files")
@@ -92,31 +97,30 @@ parser.add_argument("--service-type-identifier", help="Save certs by Service Typ
 args = parser.parse_args()
 
 if args.output_folder:
-  if os.path.exists(args.output_folder):
-    if not os.path.isdir(args.output_folder):
-      print("Impossible to save certificates in `%s': file exists and is not a folder." % args.output_folder)
-      sys.exit(1)
-  else:
-    os.makedirs(args.output_folder)
+    if os.path.exists(args.output_folder):
+        if not os.path.isdir(args.output_folder):
+            print("Impossible to save certificates in `%s': file exists and is not a folder." % args.output_folder)
+            sys.exit(1)
+    else:
+        os.makedirs(args.output_folder)
 elif args.output_file:
-  if os.path.exists(args.output_file):
-    if not os.path.isfile(args.output_file):
-      print("Impossible to write on `%s', it's not a file." % args.output_file)
-      sys.exit(1)
+    if os.path.exists(args.output_file):
+        if not os.path.isfile(args.output_file):
+            print("Impossible to write on `%s', it's not a file." % args.output_file)
+            sys.exit(1)
 
-    print("File `%s' will be overwritten..." % args.output_file)
-
+        print("File `%s' will be overwritten..." % args.output_file)
 
 if args.cert_file:
-  tree = etree.parse(args.cert_file)
-  root = tree.getroot()
+    tree = etree.parse(args.cert_file)
+    root = tree.getroot()
 else:
-  root = etree.fromstring(get_certs_xml().read())
+    root = etree.fromstring(get_certs_xml().read())
 
 try:
-  [default_namespace] = re.findall("({[^}]*}).*", root.tag)
+    [default_namespace] = re.findall("({[^}]*}).*", root.tag)
 except:
-  default_namespace = ""
+    default_namespace = ""
 
 print("Namespace: `%s`", default_namespace)
 
@@ -142,40 +146,40 @@ else:
     services = root.xpath(query, namespaces=ns)
 
 if args.output_folder:
-  for service in services:
-    try:      
-        info = get_service_info(service, default_namespace)
-        name = re.sub('[A-z]{1,2}=', '_', re.sub('[/\,\' "]', '_', info['name'])).replace('__', '_').strip('_- ')
-        filename = name
+    for service in services:
+        try:
+            info = get_service_info(service, default_namespace)
+            name = re.sub('[A-z]{1,2}=', '_', re.sub('[/\,\' "]', '_', info['name'])).replace('__', '_').strip('_- ')
+            filename = name
 
-        idx = 1
-        tmpname = filename
-        while os.path.exists(os.path.join(args.output_folder, tmpname + EXTENSION)):
-            tmpname = filename + str(idx)
-            idx += 1
-        filename = tmpname + EXTENSION
+            idx = 1
+            tmpname = filename
+            while os.path.exists(os.path.join(args.output_folder, tmpname + EXTENSION)):
+                tmpname = filename + str(idx)
+                idx += 1
+            filename = tmpname + EXTENSION
 
-        f = safe_open(filename, args.output_folder, 'w')
-        write_certificate(f, info['x509_cert'])
-        f.close()
-        print("Added certificate: %s" % filename)
+            f = safe_open(filename, args.output_folder, 'w')
+            write_certificate(f, info['x509_cert'])
+            f.close()
+            print("Added certificate: %s" % filename)
 
-    except Exception as e:
-        print("Impossible to add file: %s" % e)
-        pass
+        except Exception as e:
+            print("Impossible to add file: %s" % e)
+            pass
 
 else:
-  f = safe_open(args.output_file, '/', 'w')
+    f = safe_open(args.output_file, '/', 'w')
 
-  for service in services:
-    try:
-      info = get_service_info(service)
-      write_certificate(f, info['x509_cert'])
+    for service in services:
+        try:
+            info = get_service_info(service)
+            write_certificate(f, info['x509_cert'])
 
-      print("Added certificate %s" % info['name'])
+            print("Added certificate %s" % info['name'])
 
-    except Exception as e:
-      print("Impossible to add certificate to file: %s" % e)
-      pass
+        except Exception as e:
+            print("Impossible to add certificate to file: %s" % e)
+            pass
 
-  f.close()
+    f.close()

--- a/scripts/parse-gov-certs.py
+++ b/scripts/parse-gov-certs.py
@@ -118,12 +118,10 @@ if args.cert_file:
 else:
     root = etree.fromstring(get_certs_xml().read())
 
-try:
-    [default_namespace] = re.findall("({[^}]*}).*", root.tag)
-except:
-    default_namespace = ""
+default_namespace = re.search(r"{[^}]*}", root.tag)
+default_namespace = default_namespace.group(0) if default_namespace else ""
 
-print("Namespace: `%s`" % default_namespace)
+print(f"Namespace: {default_namespace}")
 
 # Dizionario dei namespace
 ns = {

--- a/scripts/parse-gov-certs.py
+++ b/scripts/parse-gov-certs.py
@@ -88,6 +88,20 @@ def safe_open(file_path, base_path, mode='r'):
     return open(full_path, mode)
 
 
+def sanitize_certificate_name(service_name):
+    r"""
+    Sanitize the certificate name according to the defined rules:
+    1. Replace `/`, `\`, `'`, `"`, spaces, and `@` with `_`.
+    2. Replace prefixes matching `[A-z]{1,2}=` with `_`.
+    3. Remove double underscores (`__`).
+    4. Strip leading and trailing `_` or `-`.
+    5. Remove the characters `.`, `-`, and `=`.
+    """
+    sanitized_name = re.sub(r'[A-z]{1,2}=', '_', re.sub(r'[/\\,\' "\.\-@]', '_', service_name))
+    sanitized_name = re.sub(r'__+', '_', sanitized_name).strip('_-')
+    return sanitized_name
+
+
 parser = argparse.ArgumentParser()
 action = parser.add_mutually_exclusive_group(required=True)
 action.add_argument("--output-folder", help="Where to save the certs files")
@@ -122,7 +136,7 @@ try:
 except:
     default_namespace = ""
 
-print("Namespace: `%s`", default_namespace)
+print("Namespace: `%s`" % default_namespace)
 
 # Dizionario dei namespace
 ns = {
@@ -149,7 +163,7 @@ if args.output_folder:
     for service in services:
         try:
             info = get_service_info(service, default_namespace)
-            name = re.sub('[A-z]{1,2}=', '_', re.sub('[/\,\' "]', '_', info['name'])).replace('__', '_').strip('_- ')
+            name = sanitize_certificate_name(info['name'])
             filename = name
 
             idx = 1

--- a/scripts/parse-gov-certs.py
+++ b/scripts/parse-gov-certs.py
@@ -33,7 +33,6 @@
 # Current XML file:
 #  - https://eidas.agid.gov.it/TL/TSL-IT.xml
 
-from pathlib import Path
 from lxml import etree
 import argparse
 import re

--- a/scripts/parse-gov-certs.py
+++ b/scripts/parse-gov-certs.py
@@ -157,37 +157,20 @@ if args.output_folder:
     for service in services:
         try:
             info = get_service_info(service, default_namespace)
-            name = sanitize_certificate_name(info['name'])
-            filename = name
-
-            idx = 1
-            tmpname = filename
-            while os.path.exists(os.path.join(args.output_folder, tmpname + EXTENSION)):
-                tmpname = filename + str(idx)
-                idx += 1
-            filename = tmpname + EXTENSION
-
-            f = safe_open(filename, args.output_folder, 'w')
-            write_certificate(f, info['x509_cert'])
-            f.close()
-            print("Added certificate: %s" % filename)
-
+            filename = sanitize_certificate_name(info['name'])
+            while os.path.exists(os.path.join(args.output_folder, filename + EXTENSION)):
+                filename += "1"
+            with safe_open(filename + EXTENSION, args.output_folder, 'w') as f:
+                write_certificate(f, info['x509_cert'])
+            print(f"Added certificate: {filename + EXTENSION}")
         except Exception as e:
-            print("Impossible to add file: %s" % e)
-            pass
-
+            print(f"Error adding file: {e}")
 else:
-    f = safe_open(args.output_file, '/', 'w')
-
-    for service in services:
-        try:
-            info = get_service_info(service)
-            write_certificate(f, info['x509_cert'])
-
-            print("Added certificate %s" % info['name'])
-
-        except Exception as e:
-            print("Impossible to add certificate to file: %s" % e)
-            pass
-
-    f.close()
+    with safe_open(args.output_file, '/', 'w') as f:
+        for service in services:
+            try:
+                info = get_service_info(service, default_namespace)
+                write_certificate(f, info['x509_cert'])
+                print(f"Added certificate: {info['name']}")
+            except Exception as e:
+                print(f"Error adding certificate: {e}")

--- a/scripts/parse-gov-certs.py
+++ b/scripts/parse-gov-certs.py
@@ -173,7 +173,7 @@ def sanitize_certificate_name(service_name):
     Returns:
         str: Sanitized certificate name.
     """
-    sanitized_name = re.sub(r'[A-z]{1,2}=', '_', re.sub(r'[/\\,\' ".\-@]', '_', service_name))
+    sanitized_name = re.sub(r'[A-z]{1,2}=', '_', re.sub(r'[=/\\,\' ".\-@]', '_', service_name))
     sanitized_name = re.sub(r'__+', '_', sanitized_name).strip('_-')
     return sanitized_name
 

--- a/scripts/parse-gov-certs.py
+++ b/scripts/parse-gov-certs.py
@@ -90,7 +90,7 @@ def sanitize_certificate_name(service_name):
     4. Strip leading and trailing `_` or `-`.
     5. Remove the characters `.`, `-`, and `=`.
     """
-    sanitized_name = re.sub(r'[A-z]{1,2}=', '_', re.sub(r'[/\\,\' "\.\-@]', '_', service_name))
+    sanitized_name = re.sub(r'[A-z]{1,2}=', '_', re.sub(r'[/\\,\' ".\-@]', '_', service_name))
     sanitized_name = re.sub(r'__+', '_', sanitized_name).strip('_-')
     return sanitized_name
 

--- a/scripts/parse-gov-certs.py
+++ b/scripts/parse-gov-certs.py
@@ -57,9 +57,10 @@ def write_certificate(file, cert):
 
 
 def get_service_info(service, namespace):
-    name = service.find("*/" + namespace + "Name").text
-    x509_cert = service.find("*//" + namespace + "X509Certificate").text
-    return {'name': name, 'x509_cert': x509_cert}
+    return {
+        'name': service.find(f"*/{namespace}Name").text,
+        'x509_cert': service.find(f"*//{namespace}X509Certificate").text
+    }
 
 
 def safe_open(file_path, base_path, mode='r'):

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+cryptography>=3.4
+lxml>=4.6


### PR DESCRIPTION
### Added
- Sullo script `parse-gov-certs.py` è stata aggiunta la funzionalità di controllo della validità del certificato (scadenza)
- Aggiunto il file requirements.txt per la gestione delle dipendenze Python qualora si volesse eseguire lo script `parse-gov-certs.py` al di fuori del container Docker

### Changed
- Aggiornamento della documentazione (README)
- Aggiornamento della documentazione doc-style dello script `parse-gov-certs.py`
- Refactoring dello script `parse-gov-certs.py` per rimuovere vecchio codice di compatibilità con Python 2
- Aggiornamento del Dockerfile per l'installazione delle dipendenze Python aggiuntive

### Fixed
- Revisione della funzione di sanificazione del nome del certificato
